### PR TITLE
feat: add columns for translations if present, removed nan for numpy compatibility

### DIFF
--- a/datavolley/helpers.py
+++ b/datavolley/helpers.py
@@ -123,7 +123,7 @@ desired_order = [
     'visiting_player_id4', 'visiting_player_id5', 'visiting_player_id6', 'set_number', 'home_team','visiting_team', 
     'home_team_id', 'visiting_team_id', 'team_id', 'point_won_by', 'winning_attack', 'serving_team', 'receiving_team', 
     'phase', 'home_score_start_of_point', 'visiting_score_start_of_point', 'rally_number', "possesion_number",
-    "translated_attack_code", "translated_set_code", 'shot_type'
+    "attack_description", "set_description", 'skill_type'
     ]
 
 def dv_index2xy(i):

--- a/datavolley/helpers.py
+++ b/datavolley/helpers.py
@@ -10,6 +10,30 @@ def get_teams(rows_list):
     visiting_team = rows_list[teams_index + 2].strip()
     return home_team, visiting_team
 
+def get_attack_combinations(rows_list):
+    # Find the index of [3ATTACKCOMBINATION]
+    attack_combinations_index = rows_list.index('[3ATTACKCOMBINATION]\n')
+    # Extract attack_combinations
+    attack_combinations = {}
+    for idx in range(1, len(rows_list)):
+        if rows_list[attack_combinations_index + idx] == '[3SETTERCALL]\n':
+            break
+        splitted_combinations = rows_list[attack_combinations_index + idx + 1].strip().split(";")
+        attack_combinations[splitted_combinations[0]] = splitted_combinations[4] if len(splitted_combinations) > 4 else None
+    return attack_combinations
+
+def get_setter_calls(rows_list):
+    # Find the index of [3SETTERCALL]
+    setter_calls_index = rows_list.index('[3SETTERCALL]\n')
+    # Extract setter_calls
+    setter_calls = {}
+    for idx in range(1, len(rows_list)):
+        if rows_list[setter_calls_index + idx] == '[3WINNINGSYMBOLS]\n':
+            break
+        splitted_calls = rows_list[setter_calls_index + idx + 1].strip().split(";")
+        setter_calls[splitted_calls[0]] = splitted_calls[2] if len(splitted_calls) > 2 else None
+    return setter_calls
+
 def get_match(rows_list):
     # Find the index of [3MATCH]
     
@@ -98,7 +122,8 @@ desired_order = [
     'home_player_id5', 'home_player_id6', 'visiting_player_id1', 'visiting_player_id2', 'visiting_player_id3',
     'visiting_player_id4', 'visiting_player_id5', 'visiting_player_id6', 'set_number', 'home_team','visiting_team', 
     'home_team_id', 'visiting_team_id', 'team_id', 'point_won_by', 'winning_attack', 'serving_team', 'receiving_team', 
-    'phase', 'home_score_start_of_point', 'visiting_score_start_of_point', 'rally_number', "possesion_number"
+    'phase', 'home_score_start_of_point', 'visiting_score_start_of_point', 'rally_number', "possesion_number",
+    "translated_attack_code", "translated_set_code", 'shot_type'
     ]
 
 def dv_index2xy(i):

--- a/datavolley/read_dv.py
+++ b/datavolley/read_dv.py
@@ -315,15 +315,15 @@ class DataVolley:
         plays['evaluation'] = plays.apply(lambda row: evaluation_mapping.get(row['skill'], {}).get(row['evaluation_code'], ""), axis=1)
 
         # Add shoot type
-        plays["shot_type"] = plays.apply(lambda row: row['code'][4] if len(row['code']) > 4 else None, axis=1)
+        plays["skill_type "] = plays.apply(lambda row: row['code'][4] if len(row['code']) > 4 else None, axis=1)
 
         # Add attack combinations
         attack_combinations = get_attack_combinations(rows)
-        plays['translated_attack_code'] = plays.apply(lambda row: attack_combinations.get(row['attack_code'], ""), axis=1)
+        plays['attack_description'] = plays.apply(lambda row: attack_combinations.get(row['attack_code'], ""), axis=1)
 
         # Add setter calls
         setter_calls = get_setter_calls(rows)
-        plays['translated_set_code'] = plays.apply(lambda row: setter_calls.get(row['set_code'], ""), axis=1)
+        plays['set_description'] = plays.apply(lambda row: setter_calls.get(row['set_code'], ""), axis=1)
 
 
         # Reorder columns


### PR DESCRIPTION
This should add three columns:
- ~`translated_attack_code`~ `attack_description` : a human readable version of `attack_code` using the `3ATTACKCOMBINATION` portion of the `.dvw` file.
- ~`translated_set_code`~ `set_description`: a human readable version of  `set_code` using the `3SETTERCALL` portion of the `.dvw` file.
- ~`shot_type`~  `skill_type`: the code of the shot type.

It also changes a np.NaN to a np.nan to allow numpy 2 compatibility.